### PR TITLE
Pin the frontend image to a specific tag

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@ services:
     restart: always
     logging: *default-logging
   frontend:
-    image: lblod/frontend-contact-hub
+    image: lblod/frontend-contact-hub:0.2.0
     labels:
       - "logging=true"
     environment: 


### PR DESCRIPTION
This pins the frontend image to the v0.2.0 release. Future releases will require a version bump here as well.

The dev environment has already been updated to use the latest tag instead.