### PR TITLE
Don't restart the triplestore service in dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,12 +8,11 @@ services:
   dispatcher:
     restart: "no"
   triplestore:
+    ports: 
+      - "8890:8890"
     restart: "no"
   db:
     restart: "no"
-  triplestore:
-    ports: 
-      - "8890:8890"
   migrations:
     restart: "no"
   resource:


### PR DESCRIPTION
It seems the triplestore key was listed twice and the second one overrode the first version, so the service would be restarted automatically.