### PR TITLE
Make sure financing percentages are sorted as expected

### DIFF
--- a/config/migrations/20210909152600-fix-percentage-sort-part-1.sparql
+++ b/config/migrations/20210909152600-fix-percentage-sort-part-1.sparql
@@ -1,0 +1,22 @@
+PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
+PREFIX  ere:  <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX  ext:  <http://mu.semte.ch/vocabularies/ext/>
+
+# Convert the xsd:float typed percentages to xsd:decimal.
+# This is needed to work around a sorting issue that only happens with xsd:float.
+# The migration file is split up in 2 parts since Virtuoso has issues with doing the conversion in a single migration file.
+
+DELETE {
+  GRAPH ?g {
+    ?s ere:financieringspercentage ?percentage.
+  }
+} INSERT {
+  GRAPH ?g {
+    ?s ext:decimalPercentage ?decimalPercentage.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s ere:financieringspercentage ?percentage.
+    BIND (ROUND(xsd:decimal(?percentage)*100)/100 AS ?decimalPercentage).
+  }
+}

--- a/config/migrations/20210909152630-fix-percentage-sort-part-2.sparql
+++ b/config/migrations/20210909152630-fix-percentage-sort-part-2.sparql
@@ -1,0 +1,19 @@
+PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
+PREFIX  ere:  <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX  ext:  <http://mu.semte.ch/vocabularies/ext/>
+
+# Part 2 of the percentage sort fix.
+
+DELETE {
+  GRAPH ?g {
+    ?s ext:decimalPercentage ?percentage.
+  }
+} INSERT {
+  GRAPH ?g {
+    ?s ere:financieringspercentage ?percentage.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s ext:decimalPercentage ?percentage.
+  }
+}


### PR DESCRIPTION
It seems that something in the Semantic Works stack doesn't handle sorting values with the xsd:floats type properly. The frontend receives the records in the wrong order.

Explicitly converting the floats to a xsd:decimal solves the problem so we use that as a workaround for now.