### PR TITLE
bestuurseenheid hierarchy

### DIFF
--- a/config/migrations/20211001-meta.ttl
+++ b/config/migrations/20211001-meta.ttl
@@ -1,0 +1,7 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+ere:CentraalBestuurVanDeEredienst rdfs:subClassOf besluit:Bestuurseenheid.
+ere:BestuurVanDeEredienst rdfs:subClassOf besluit:Bestuurseenheid.
+ere:RepresentatiefOrgaan rdfs:subClassOf besluit:Bestuurseenheid.


### PR DESCRIPTION
Adding the hierarchy to enable more elegant sparql queries. i.e. use the subclass information to query for all possible bestuurseenheden.