### PR TITLE
Add x-frame-options when hosting frontend pages

### DIFF
--- a/config/frontend/add-x-frame-options-header.conf
+++ b/config/frontend/add-x-frame-options-header.conf
@@ -1,3 +1,3 @@
 location / {
-  add_header X-Frame-Options "DENY";
+  add_header X-Frame-Options "DENY" always;
 }

--- a/config/frontend/add-x-frame-options-header.conf
+++ b/config/frontend/add-x-frame-options-header.conf
@@ -1,0 +1,3 @@
+location / {
+  add_header X-Frame-Options "DENY";
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,8 @@ services:
     image: lblod/frontend-contact-hub:1.1.0
     labels:
       - "logging=true"
+    volumes:
+      - ./config/frontend/add-x-frame-options-header.conf:/config/add-x-frame-options.conf
     environment:
       EMBER_OAUTH_API_REDIRECT_URL: "https://organisaties.abb.lblod.info/authorization/callback"
       EMBER_OAUTH_API_KEY: "677af572-2e2f-4e61-ad38-036723bb314c"


### PR DESCRIPTION
We don't want these pages to be contained in a frame.  The x-frame-options serves that use.

To my understanding, it's fine if this is executed for all html pages.  Any attack would need to confuse people, and hence would need them to be visit a page.  Hence this is the right place to my understanding.  Feel free to verify that assumption.