### PR TITLE
Enable the uri-info service again

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -243,6 +243,10 @@ defmodule Dispatcher do
     forward conn, path, "http://privacy/person-information-requests"
   end
 
+  get "/uri-info/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    forward conn, path, "http://uri-info/"
+  end
+
 
   ###############################################################
   # frontend layer

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,3 +35,5 @@ services:
     restart: "no"
   frontend:
     restart: "no"
+  uri-info:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,3 +146,11 @@ services:
       EMBER_OAUTH_API_LOGOUT_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/logout"
       EMBER_OAUTH_API_SCOPE: "openid vo profile abb_organisatieportaal"
     restart: always
+  uri-info:
+    image: redpencil/mu-uri-info-service:0.2.1
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+    links:
+      - db:database


### PR DESCRIPTION
This allows us to retrieve the rdf type and uuid of a resource uri.