### PR TITLE
Prevent services from restarting in development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
   kalliope-api:
     environment:
       SPRING_SECURITY_CONFIG: "/config/security-dev.yml"
-      restart: "no"
+    restart: "no"
   deltanotifier:
     restart: "no"
   mocklogin:
@@ -32,6 +32,12 @@ services:
   sink:
     restart: "no"
   login:
+    restart: "no"
+  accountdetail:
+    restart: "no"
+  privacy:
+    restart: "no"
+  adressenregister:
     restart: "no"
   frontend:
     restart: "no"


### PR DESCRIPTION
I noticed some services didn't have the auto restart disabled in the dev config.