### PR TITLE
Feature/delta producer administrative units

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,37 @@ Backend for the Contact Hub application based on the  mu.semte.ch microservices 
 You can shut down using `docker-compose stop` and remove everything using `docker-compose rm`.
 
 
+### Setting up the delta-producers related services
+To make sure the app can share data, producers need to be set up. There is an intial sync, that is potentially very expensive, and must be started manually
+
+#### producers administrative-units
+
+1. make sure the app is up and running, the migrations have run
+2. in docker-compose.override.yml, make sure the following configuration is provided:
+```
+  delta-producer-pub-graph-maintainer-administrative-units:
+    environment:
+      START_INITIAL_SYNC: 'true'
+```
+3. `drc up -d delta-producer-pub-graph-maintainer-administrative-units`
+4. You can follow the status of the job, ideally through the dashboard, but this hasn't been setup yet. The following query should also give results:
+```
+   PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+   PREFIX adms: <http://www.w3.org/ns/adms#>
+   PREFIX dct: <http://purl.org/dc/terms/>
+
+    SELECT DISTINCT ?job ?operation ?created ?modified ?status WHERE {
+       GRAPH ?g {
+         ?job a <http://vocab.deri.ie/cogs#Job>;
+              task:operation ?operation;
+              adms:status ?status;
+              dct:created ?created;
+              dct:modified ?modified.
+       }
+       FILTER( ?operation IN (
+         <http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/administrative-units>,
+         <http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/healingOperation/administrative-units>
+        )
+       )
+     }
+```

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -32,7 +32,7 @@ defmodule Acl.UserGroups.Config do
                         "http://schema.org/ContactPoint",
                         "http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie",
                         "http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst",
-                        "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan",                          
+                        "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan",
                         "http://www.w3.org/ns/org#Role",
                         "http://www.w3.org/ns/org#Post",
                         "http://data.lblod.info/vocabularies/contacthub/AgentInPositie",
@@ -107,21 +107,21 @@ defmodule Acl.UserGroups.Config do
       %GroupSpec{
         name: "public",
         useage: [:read],
-        access: %AlwaysAccessible{}, 
+        access: %AlwaysAccessible{},
         graphs: [ %GraphSpec{
                     graph: "http://mu.semte.ch/graphs/public", # mock login only
                     constraint: %ResourceConstraint{
                       resource_types: [
                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
                         "http://xmlns.com/foaf/0.1/Person",
-                        "http://xmlns.com/foaf/0.1/OnlineAccount"
+                        "http://xmlns.com/foaf/0.1/OnlineAccount",
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
                         "http://www.w3.org/ns/dcat#Dataset",
                         "http://www.w3.org/ns/dcat#Distribution",
                         "http://www.w3.org/ns/dcat#Catalog"
                       ]
                     } }]},
-  
+
       # // CLEANUP
       #
       %GraphCleanup{

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -116,6 +116,9 @@ defmodule Acl.UserGroups.Config do
                         "http://xmlns.com/foaf/0.1/Person",
                         "http://xmlns.com/foaf/0.1/OnlineAccount"
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
+                        "http://www.w3.org/ns/dcat#Dataset",
+                        "http://www.w3.org/ns/dcat#Distribution",
+                        "http://www.w3.org/ns/dcat#Catalog"
                       ]
                     } }]},
   

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -115,6 +115,7 @@ defmodule Acl.UserGroups.Config do
                         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
                         "http://xmlns.com/foaf/0.1/Person",
                         "http://xmlns.com/foaf/0.1/OnlineAccount"
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
                       ]
                     } }]},
   

--- a/config/delta-producer/administrative-units/export.json
+++ b/config/delta-producer/administrative-units/export.json
@@ -1,0 +1,65 @@
+{
+  "export": [
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2004/02/skos/core#scopeNote"
+      ]
+    },
+    {
+      "type": "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2004/02/skos/core#altLabel",
+        "http://data.vlaanderen.be/ns/besluit#werkingsgebied",
+        "http://www.w3.org/ns/org#classification"
+      ]
+    },
+    {
+      "type": "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://data.vlaanderen.be/ns/besluit#bestuurt",
+        "http://www.w3.org/ns/org#classification",
+        "http://data.vlaanderen.be/ns/mandaat#bindingEinde",
+        "http://data.vlaanderen.be/ns/mandaat#bindingStart",
+        "https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2004/02/skos/core#scopeNote"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/ns/prov#Location",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2000/01/rdf-schema#label",
+        "http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau"
+      ]
+    }
+  ]
+}

--- a/config/delta-producer/dump-file-publisher/config.json
+++ b/config/delta-producer/dump-file-publisher/config.json
@@ -1,0 +1,12 @@
+{
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/administrative-units" : {
+    "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/AdministrativeUnitsCacheGraphDump",
+    "targetGraph": "http://redpencil.data.gift/id/deltas/producer/administrative-units",
+    "fileBaseName": "dump-administrative-units"
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/administrative-units" : {
+    "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/AdministrativeUnitsCacheGraphDump",
+    "targetGraph": "http://redpencil.data.gift/id/deltas/producer/administrative-units",
+    "fileBaseName": "dump-administrative-units"
+  }
+}

--- a/config/delta-producer/dump-file-publisher/config.json
+++ b/config/delta-producer/dump-file-publisher/config.json
@@ -8,5 +8,15 @@
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/AdministrativeUnitsCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/administrative-units",
     "fileBaseName": "dump-administrative-units"
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/organizations" : {
+    "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/OrganizationsCacheGraphDump",
+    "targetGraph": "http://redpencil.data.gift/id/deltas/producer/organizations",
+    "fileBaseName": "dump-administrative-units"
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/organizations" : {
+    "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/OrganizationsCacheGraphDump",
+    "targetGraph": "http://redpencil.data.gift/id/deltas/producer/organizations",
+    "fileBaseName": "dump-administrative-units"
   }
 }

--- a/config/delta-producer/organizations/export.json
+++ b/config/delta-producer/organizations/export.json
@@ -72,10 +72,7 @@
       "properties": [
         "http://www.w3.org/ns/org#role",
         "http://www.w3.org/ns/org#postIn",
-        "^http://www.w3.org/ns/org#holds",
-        "http://www.w3.org/ns/org#role",
-        "^http://www.w3.org/ns/org#hasPost",
-        "^http://www.w3.org/ns/org#holds"
+        "http://www.w3.org/ns/org#role"
       ]
     },
     {
@@ -115,6 +112,32 @@
       ]
     },
     {
+      "type": "http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst",
+      "strictTypeExport": "true",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2004/02/skos/core#altLabel",
+        "http://www.w3.org/ns/adms#identifier",
+        "http://www.w3.org/ns/regorg#orgStatus",
+        "http://www.w3.org/ns/org#hasPrimarySite",
+        "http://www.w3.org/ns/org#hasSite",
+        "http://www.w3.org/ns/org#changedBy",
+        "http://www.w3.org/ns/org#resultedFrom",
+        "http://www.w3.org/ns/org#hasPost",
+        "http://www.w3.org/ns/org#linkedTo",
+        "http://www.w3.org/ns/org#hasSubOrganization",
+        "http://www.w3.org/ns/org#classification",
+        "http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur",
+        "http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau",
+        "http://data.lblod.info/vocabularies/erediensten/denominatie",
+        "http://data.lblod.info/vocabularies/erediensten/grensoverschrijdend",
+        "http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor"
+      ]
+    },
+    {
       "type": "http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst",
       "strictTypeExport": "true",
       "graphsFilter": [
@@ -132,13 +155,9 @@
         "http://www.w3.org/ns/org#hasPost",
         "http://www.w3.org/ns/org#linkedTo",
         "http://www.w3.org/ns/org#hasSubOrganization",
-        "^http://www.w3.org/ns/org#linkedTo",
-        "^http://www.w3.org/ns/org#hasSubOrganization",
         "http://www.w3.org/ns/org#classification",
-        "^http://data.vlaanderen.be/ns/besluit#bestuurt",
         "http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur",
-        "http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau",
-        "^http://data.lblod.info/vocabularies/erediensten/typeEredienst"
+        "http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau"
       ]
     },
     {
@@ -159,10 +178,7 @@
         "http://www.w3.org/ns/org#hasPost",
         "http://www.w3.org/ns/org#linkedTo",
         "http://www.w3.org/ns/org#hasSubOrganization",
-        "^http://www.w3.org/ns/org#linkedTo",
-        "^http://www.w3.org/ns/org#hasSubOrganization",
-        "http://data.lblod.info/vocabularies/erediensten/typeEredienst",
-        "^http://data.lblod.info/vocabularies/erediensten/behoort"
+        "http://data.lblod.info/vocabularies/erediensten/typeEredienst"
       ]
     },
     {
@@ -177,7 +193,6 @@
         "http://data.vlaanderen.be/ns/besluit#bestuurt",
         "http://www.w3.org/ns/org#classification",
         "https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan",
-        "^https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan",
         "http://www.w3.org/ns/org#hasPost"
       ]
     },
@@ -198,8 +213,7 @@
       "properties": [
         "http://data.lblod.info/vocabularies/erediensten/financieringspercentage",
         "http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid",
-        "http://www.w3.org/ns/org#organization",
-        "^http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur"
+        "http://www.w3.org/ns/org#organization"
       ]
     },
     {
@@ -352,9 +366,7 @@
       "properties": [
         "http://www.w3.org/ns/org#role",
         "http://www.w3.org/ns/org#postIn",
-        "^http://www.w3.org/ns/org#holds",
         "http://data.lblod.info/vocabularies/erediensten/functie",
-        "^http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor",
         "http://data.lblod.info/vocabularies/erediensten/behoort"
       ]
     },

--- a/config/delta-producer/organizations/export.json
+++ b/config/delta-producer/organizations/export.json
@@ -1,0 +1,407 @@
+{
+  "export": [
+    {
+      "type": "http://www.w3.org/ns/person#Person",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [ 
+        "http://xmlns.com/foaf/0.1/givenName",
+        "http://xmlns.com/foaf/0.1/familyName",
+        "https://data.vlaanderen.be/ns/persoon#gebruikteVoornaam",
+        "http://data.vlaanderen.be/ns/mandaat#isAangesteldAls",
+        "http://www.w3.org/ns/org#heldBy"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://data.lblod.info/vocabularies/erediensten/EredienstMandataris",
+      "strictTypeExport": "true",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://data.lblod.info/vocabularies/contacthub/startdatum",
+        "http://data.lblod.info/vocabularies/contacthub/eindedatum",
+        "http://www.w3.org/ns/org#holds",
+        "http://www.w3.org/ns/org#heldBy",
+        "http://schema.org/contactPoint",
+        "http://data.vlaanderen.be/ns/mandaat#start",
+        "http://data.vlaanderen.be/ns/mandaat#einde",
+        "http://data.vlaanderen.be/ns/mandaat#status",
+        "http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan",
+        "http://data.lblod.info/vocabularies/erediensten/geplandeEinddatumAanstelling",
+        "http://data.lblod.info/vocabularies/erediensten/redenVanStopzetting",
+        "http://data.lblod.info/vocabularies/erediensten/typeHelft"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/HelftVerkiezing",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://schema.org/ContactPoint",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://schema.org/email",
+        "http://schema.org/faxNumber",
+        "http://schema.org/telephone",
+        "http://www.w3.org/ns/locn#address"
+      ]
+    },
+    {
+      "type": "http://data.vlaanderen.be/ns/mandaat#Mandaat",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/ns/org#role",
+        "http://www.w3.org/ns/org#postIn",
+        "^http://www.w3.org/ns/org#holds",
+        "http://www.w3.org/ns/org#role",
+        "^http://www.w3.org/ns/org#hasPost",
+        "^http://www.w3.org/ns/org#holds"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/ns/org#Role",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/TypeEredienst",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst",
+      "strictTypeExport": "true",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2004/02/skos/core#altLabel",
+        "http://www.w3.org/ns/adms#identifier",
+        "http://www.w3.org/ns/regorg#orgStatus",
+        "http://www.w3.org/ns/org#hasPrimarySite",
+        "http://www.w3.org/ns/org#hasSite",
+        "http://www.w3.org/ns/org#changedBy",
+        "http://www.w3.org/ns/org#resultedFrom",
+        "http://www.w3.org/ns/org#hasPost",
+        "http://www.w3.org/ns/org#linkedTo",
+        "http://www.w3.org/ns/org#hasSubOrganization",
+        "^http://www.w3.org/ns/org#linkedTo",
+        "^http://www.w3.org/ns/org#hasSubOrganization",
+        "http://www.w3.org/ns/org#classification",
+        "^http://data.vlaanderen.be/ns/besluit#bestuurt",
+        "http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur",
+        "http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau",
+        "^http://data.lblod.info/vocabularies/erediensten/typeEredienst"
+      ]
+    },
+    {
+      "type": "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan",
+      "strictTypeExport": "true",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2004/02/skos/core#altLabel",
+        "http://www.w3.org/ns/adms#identifier",
+        "http://www.w3.org/ns/regorg#orgStatus",
+        "http://www.w3.org/ns/org#hasPrimarySite",
+        "http://www.w3.org/ns/org#hasSite",
+        "http://www.w3.org/ns/org#changedBy",
+        "http://www.w3.org/ns/org#resultedFrom",
+        "http://www.w3.org/ns/org#hasPost",
+        "http://www.w3.org/ns/org#linkedTo",
+        "http://www.w3.org/ns/org#hasSubOrganization",
+        "^http://www.w3.org/ns/org#linkedTo",
+        "^http://www.w3.org/ns/org#hasSubOrganization",
+        "http://data.lblod.info/vocabularies/erediensten/typeEredienst",
+        "^http://data.lblod.info/vocabularies/erediensten/behoort"
+      ]
+    },
+    {
+      "type": "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
+      "strictTypeExport": "true",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://data.vlaanderen.be/ns/mandaat#bindingEinde",
+        "http://data.vlaanderen.be/ns/mandaat#bindingStart",
+        "http://data.vlaanderen.be/ns/besluit#bestuurt",
+        "http://www.w3.org/ns/org#classification",
+        "https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan",
+        "^https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan",
+        "http://www.w3.org/ns/org#hasPost"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://data.lblod.info/vocabularies/erediensten/financieringspercentage",
+        "http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid",
+        "http://www.w3.org/ns/org#organization",
+        "^http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/ns/adms#Identifier",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#notation",
+        "https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator"
+      ]
+    },
+    {
+      "type": "https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "https://data.vlaanderen.be/ns/generiek#lokaleIdentificator"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/ns/locn#Address",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer",
+        "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer",
+        "http://www.w3.org/ns/locn#thoroughfare",
+        "http://www.w3.org/ns/locn#postCode",
+        "https://data.vlaanderen.be/ns/adres#gemeentenaam",
+        "http://www.w3.org/ns/locn#adminUnitL2",
+        "https://data.vlaanderen.be/ns/adres#land",
+        "http://www.w3.org/ns/locn#fullAddress",
+        "https://data.vlaanderen.be/ns/adres#verwijstNaar",
+        "http://purl.org/dc/terms/source"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/ns/org#Site",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/ns/org#siteAddress",
+        "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
+        "http://data.lblod.info/vocabularies/erediensten/vestigingstype"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/ns/org#ChangeEvent",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://purl.org/dc/terms/date",
+        "http://purl.org/dc/terms/description",
+        "http://data.lblod.info/vocabularies/contacthub/typeWijziging",
+        "http://www.w3.org/ns/org#resultedFrom",
+        "http://www.w3.org/ns/org#changedBy"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/Veranderingsgebeurtenis",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/2004/02/skos/core#Concept",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/OrganisatieStatusCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://www.w3.org/ns/prov#Location",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2000/01/rdf-schema#label",
+        "http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau",
+        "http://data.vlaanderen.be/ns/besluit#werkingsgebied"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/TypeBetrokkenheid",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://data.lblod.info/vocabularies/erediensten/RolBedienaar", 
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://data.lblod.info/vocabularies/contacthub/startdatum",
+        "http://data.lblod.info/vocabularies/contacthub/eindedatum",
+        "http://www.w3.org/ns/org#holds",
+        "http://www.w3.org/ns/org#heldBy",
+        "http://schema.org/contactPoint",
+        "http://data.lblod.info/vocabularies/erediensten/financiering",
+        "http://data.lblod.info/vocabularies/erediensten/voldoetAan"
+      ]
+    },
+    {
+      "type": "http://data.lblod.info/vocabularies/erediensten/VoorwaardenBedienaar",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://data.lblod.info/vocabularies/erediensten/voldaan",
+        "http://data.lblod.info/vocabularies/erediensten/criterium",
+        "http://data.lblod.info/vocabularies/erediensten/criteriumbewijsstuktype"
+      ]
+    },{
+      "type": "http://publications.europa.eu/ontology/euvoc#Country",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2000/01/rdf-schema#label"
+      ]
+    },{
+      "type": "http://data.lblod.info/vocabularies/erediensten/PositieBedienaar",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/ns/org#role",
+        "http://www.w3.org/ns/org#postIn",
+        "^http://www.w3.org/ns/org#holds",
+        "http://data.lblod.info/vocabularies/erediensten/functie",
+        "^http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor",
+        "http://data.lblod.info/vocabularies/erediensten/behoort"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/EredienstBeroepen",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BedienaarFinanceringCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/VoorwaardenBedienaarCriterium",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BedienaarCriteriumBewijsstuk",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/TypeVestiging",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    }
+  ]
+}

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -51,6 +51,24 @@ export default [
   },
   {
     match: {
+      graph: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/id/deltas/producer/administrative-units'
+      }
+    },
+    callback: {
+      url: 'http://delta-producer-json-diff-publisher-administrative-units/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
+    }
+  },
+  {
+    match: {
       predicate: {
         type: 'uri',
         value: 'http://www.w3.org/ns/adms#status'

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -12,8 +12,10 @@ export default [
       options: {
         resourceFormat: "v0.0.1",
         gracePeriod: 1000,
-        ignoreFromSelf: true
+        ignoreFromSelf: true,
+        optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
       }
+    },
   {
     match: {
       predicate: {
@@ -89,3 +91,4 @@ export default [
       optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
     }
   }
+]

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -71,6 +71,24 @@ export default [
   },
   {
     match: {
+      graph: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/id/deltas/producer/organizations'
+      }
+    },
+    callback: {
+      url: 'http://delta-producer-json-diff-publisher-organizations/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
+    }
+  },
+  {
+    match: {
       predicate: {
         type: 'uri',
         value: 'http://www.w3.org/ns/adms#status'

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -34,6 +34,23 @@ export default [
   },
   {
     match: {
+    },
+    callback: {
+      url: 'http://delta-producer-pub-graph-maintainer-administrative-units/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: [
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
+                        ]
+    }
+  },
+  {
+    match: {
       predicate: {
         type: 'uri',
         value: 'http://www.w3.org/ns/adms#status'

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -71,6 +71,23 @@ export default [
   },
   {
     match: {
+    },
+    callback: {
+      url: 'http://delta-producer-pub-graph-maintainer-organizations/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: [
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
+                          "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
+                        ]
+    }
+  },,
+  {
+    match: {
       graph: {
         type: 'uri',
         value: 'http://redpencil.data.gift/id/deltas/producer/organizations'

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -14,5 +14,23 @@ export default [
         gracePeriod: 1000,
         ignoreFromSelf: true
       }
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status'
+      }
+    },
+    callback: {
+      method: 'POST',
+      url: 'http://jobs-controller/delta'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
+    }
+  },
     }
   ]

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -32,5 +32,25 @@ export default [
       optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
     }
   },
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status'
+      },
+      object: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
+      }
+    },
+    callback: {
+      url: 'http://delta-producer-dump-file-publisher/delta',
+      method: 'POST'
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      optOutMuScopeIds: [ "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync" ]
     }
-  ]
+  }

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -277,6 +277,14 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://delta-producer-json-diff-file-publisher-administrative-units/files/"
   end
 
+  #################################################################
+  #  DELTA: organizations
+  #################################################################
+
+  get "/sync/organizations/files/*path" do
+    Proxy.forward conn, path, "http://delta-producer-json-diff-file-publisher-organizations/files/"
+  end
+
   ###############################################################
   # frontend layer
   ###############################################################

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -244,6 +244,17 @@ defmodule Dispatcher do
   end
 
 
+  #################################################################
+  # FILES
+  #################################################################
+
+  get "/files/:id/download", %{ accept: [:any], } do
+    Proxy.forward conn, [], "http://file/files/" <> id <> "/download"
+  end
+
+  get "/files/*path" , %{ layer: :api_services, accept: %{ json: true } } do
+    Proxy.forward conn, path, "http://cache/files/"
+  end
   ###############################################################
   # frontend layer
   ###############################################################

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -75,7 +75,7 @@ defmodule Dispatcher do
   match "/worship-administrative-units/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/worship-administrative-units/"
   end
-  
+
   match "/worship-services/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/worship-services/"
   end
@@ -126,11 +126,11 @@ defmodule Dispatcher do
 
   match "/change-event-types/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/change-event-types/"
-  end 
+  end
 
   match "/organization-status-codes/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/organization-status-codes/"
-  end   
+  end
 
   match "/locations/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/locations/"
@@ -142,15 +142,15 @@ defmodule Dispatcher do
 
   match "/ministers/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/ministers/"
-  end 
+  end
 
   match "/minister-conditions/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/minister-conditions/"
-  end 
+  end
 
   match "/dates-of-birth/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/dates-of-birth/"
-  end   
+  end
 
   match "/nationalities/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/nationalities/"
@@ -181,12 +181,12 @@ defmodule Dispatcher do
 
   match "/document-types-criterions/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/document-types-criterions/"
-  end  
+  end
 
   match "/site-types/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/site-types/"
   end
-  
+
 
   ###############
   # LOGIN
@@ -209,7 +209,7 @@ defmodule Dispatcher do
   match "/sessions/*path", %{ accept: [:any], layer: :api} do
     Proxy.forward conn, path, "http://login/sessions/"
   end
-  
+
 
   ###############
   # API SERVICES
@@ -255,6 +255,7 @@ defmodule Dispatcher do
   get "/files/*path" , %{ layer: :api_services, accept: %{ json: true } } do
     Proxy.forward conn, path, "http://cache/files/"
   end
+
   #################################################################
   # DCAT
   #################################################################
@@ -266,6 +267,8 @@ defmodule Dispatcher do
   get "/distributions/*path", %{ layer: :api_services, accept: %{ json: true } } do
     Proxy.forward conn, path, "http://cache/distributions/"
   end
+
+
   #################################################################
   #  DELTA: administrative-units
   #################################################################
@@ -273,6 +276,7 @@ defmodule Dispatcher do
   get "/sync/administrative-units/files/*path" do
     Proxy.forward conn, path, "http://delta-producer-json-diff-file-publisher-administrative-units/files/"
   end
+
   ###############################################################
   # frontend layer
   ###############################################################
@@ -296,11 +300,11 @@ defmodule Dispatcher do
   match "/*_path", %{ layer: :frontend } do
     Proxy.forward conn, [], "http://frontend/index.html"
   end
-  
+
   ###############################################################
   # sparql endpoint
   ###############################################################
-  
+
   post "/sparql/*path", %{ layer: :api_services, accept: %{ sparql_json: true } } do
     forward conn, path, "http://db:8890/sparql/"
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -256,6 +256,17 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/files/"
   end
   #################################################################
+  # DCAT
+  #################################################################
+
+  get "/datasets/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    Proxy.forward conn, path, "http://cache/datasets/"
+  end
+
+  get "/distributions/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    Proxy.forward conn, path, "http://cache/distributions/"
+  end
+  #################################################################
   #  DELTA: administrative-units
   #################################################################
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -255,6 +255,13 @@ defmodule Dispatcher do
   get "/files/*path" , %{ layer: :api_services, accept: %{ json: true } } do
     Proxy.forward conn, path, "http://cache/files/"
   end
+  #################################################################
+  #  DELTA: administrative-units
+  #################################################################
+
+  get "/sync/administrative-units/files/*path" do
+    Proxy.forward conn, path, "http://delta-producer-json-diff-file-publisher-administrative-units/files/"
+  end
   ###############################################################
   # frontend layer
   ###############################################################

--- a/config/jobs-controller/config.json
+++ b/config/jobs-controller/config.json
@@ -30,5 +30,37 @@
         "nextIndex": "0"
       }
     ]
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/organizations": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/initialPublicationGraphSyncing",
+        "nextIndex": "0"
+      }
+    ]
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/healingOperation/organizations": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/healing/patchPublicationGraph",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/initialPublicationGraphSyncing",
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation",
+        "nextIndex": "1"
+      }
+    ]
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/organizations": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation",
+        "nextIndex": "0"
+      }
+    ]
   }
 }

--- a/config/jobs-controller/config.json
+++ b/config/jobs-controller/config.json
@@ -1,0 +1,34 @@
+{
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/administrative-units": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/initialPublicationGraphSyncing",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/initialPublicationGraphSyncing",
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation",
+        "nextIndex": "1"
+      }
+    ]
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/healingOperation/administrative-units": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/healing/patchPublicationGraph",
+        "nextIndex": "0"
+      }
+    ]
+  },
+  "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/administrative-units": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation",
+        "nextIndex": "0"
+      }
+    ]
+  }
+}

--- a/config/resources/dcat.json
+++ b/config/resources/dcat.json
@@ -1,0 +1,157 @@
+{
+    "version": "0.1",
+    "prefixes": {
+        "dcat": "http://www.w3.org/ns/dcat#",
+        "dct": "http://purl.org/dc/terms/",
+        "prov": "http://www.w3.org/ns/prov#"
+    },
+    "resources": {
+        "catalogs": {
+            "class": "dcat:Catalog",
+            "attributes": {
+                "title": {
+                    "type": "string",
+                    "predicate": "dct:title"
+                },
+                "description": {
+                    "type": "string",
+                    "predicate": "dct:description"
+                },
+                "publisher": {
+                    "type": "url",
+                    "predicate": "dct:publisher"
+                },
+                "release-date": {
+                    "type": "datetime",
+                    "predicate": "dct:issued"
+                },
+                "modified": {
+                    "type": "datetime",
+                    "predicate": "dct:modified"
+                }
+            },
+            "relationships": {
+                "datasets": {
+                    "target": "datasets",
+                    "predicate": "dcat:dataset",
+                    "cardinality": "many"
+                }
+            },
+            "features": [
+                "include-uri"
+            ],
+            "new-resource-base": "http://data.lblod.info/id/catalog/"
+        },
+        "datasets": {
+            "class": "dcat:Dataset",
+            "attributes": {
+                "title": {
+                    "type": "string",
+                    "predicate": "dct:title"
+                },
+                "description": {
+                    "type": "string",
+                    "predicate": "dct:description"
+                },
+                "release-date": {
+                    "type": "datetime",
+                    "predicate": "dct:issued"
+                },
+                "modified": {
+                    "type": "datetime",
+                    "predicate": "dct:modified"
+                },
+                "type": {
+                    "type": "url",
+                    "predicate": "dct:type"
+                },
+                "subject": {
+                    "type": "url",
+                    "predicate": "dct:subject"
+                }
+            },
+            "relationships": {
+                "catalog": {
+                    "target": "catalogs",
+                    "predicate": "dcat:dataset",
+                    "cardinality": "one",
+                    "inverse": true
+                },
+                "distributions": {
+                    "target": "distributions",
+                    "predicate": "dcat:distribution",
+                    "cardinality": "many"
+                },
+                "previous-version": {
+                    "target": "datasets",
+                    "predicate": "prov:wasRevisionOf",
+                    "cardinality": "one"
+                },
+                "next-version": {
+                    "target": "datasets",
+                    "predicate": "prov:wasRevisionOf",
+                    "cardinality": "one",
+                    "inverse": true
+                }
+            },
+            "features": [
+                "include-uri"
+            ],
+            "new-resource-base": "http://data.lblod.info/id/dataset/"
+        },
+        "distributions": {
+            "class": "dcat:Distribution",
+            "attributes": {
+                "title": {
+                    "type": "string",
+                    "predicate": "dct:title"
+                },
+                "description": {
+                    "type": "string",
+                    "predicate": "dct:description"
+                },
+                "release-date": {
+                    "type": "datetime",
+                    "predicate": "dct:issued"
+                },
+                "modified": {
+                    "type": "datetime",
+                    "predicate": "dct:modified"
+                },
+                "type": {
+                    "type": "url",
+                    "predicate": "dct:type"
+                },
+                "download-url": {
+                    "type": "url",
+                    "predicate": "dcat:downloadURL"
+                },
+                "format": {
+                    "type": "string",
+                    "predicate": "dct:format"
+                },
+                "byte-size": {
+                    "type": "number",
+                    "predicate": "dcat:byteSize"
+                }
+            },
+            "relationships": {
+                "dataset": {
+                    "target": "datasets",
+                    "predicate": "dcat:distribution",
+                    "cardinality": "one",
+                    "inverse": true
+                },
+                "subject": {
+                    "target": "file",
+                    "predicate": "dct:subject",
+                    "cardinality": "one"
+                }
+            },
+            "features": [
+                "include-uri"
+            ],
+            "new-resource-base": "http://data.lblod.info/id/distribution/"
+        }
+    }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -620,7 +620,7 @@
       },
       "relationships": {
         "source": {
-          "predicate": "dct:source",
+          "predicate": "dc_terms:source",
           "target": "concepts",
           "cardinality": "one"
         }

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -1,4 +1,3 @@
-
 (in-package :mu-cl-resources)
 
 (defparameter *include-count-in-paginated-responses* t)
@@ -12,4 +11,6 @@
 (defparameter *supply-cache-headers-p* t)
 
 (read-domain-file "domain.json")
-(read-domain-file "auth.json")(read-domain-file "files-domain.lisp")
+(read-domain-file "auth.json")
+(read-domain-file "files-domain.lisp")
+(read-domain-file "dcat.json")

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -12,4 +12,4 @@
 (defparameter *supply-cache-headers-p* t)
 
 (read-domain-file "domain.json")
-(read-domain-file "auth.json")
+(read-domain-file "auth.json")(read-domain-file "files-domain.lisp")

--- a/config/resources/files-domain.lisp
+++ b/config/resources/files-domain.lisp
@@ -1,0 +1,13 @@
+(define-resource file ()
+  :class (s-prefix "nfo:FileDataObject")
+  :properties `((:filename :string ,(s-prefix "nfo:fileName"))
+                (:format :string ,(s-prefix "dct:format"))
+                (:size :number ,(s-prefix "nfo:fileSize"))
+                (:extension :string ,(s-prefix "dbpedia:fileExtension"))
+                (:created :datetime ,(s-prefix "nfo:fileCreated")))
+  :has-one `((file :via ,(s-prefix "nie:dataSource")
+                   :inverse t
+                   :as "download"))
+  :resource-base (s-url "http://data.lblod.info/files/")
+  :features `(no-pagination-defaults include-uri)
+  :on-path "files")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,3 +193,18 @@ services:
       - db:database
     volumes:
       - ./config/jobs-controller/:/config/
+################################################################################
+# DELTA GENERAL
+################################################################################
+  delta-producer-dump-file-publisher:
+    image: lblod/delta-producer-dump-file-publisher:0.4.0
+    volumes:
+      - ./config/delta-producer/dump-file-publisher:/config
+      - ./data/files:/share
+    environment:
+      FILES_GRAPH: 'http://mu.semte.ch/graphs/public' # Note: this will be extracted in a config per job one day
+      DCAT_DATASET_GRAPH: 'http://mu.semte.ch/graphs/public'
+    links:
+      - db:database
+    restart: always
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,7 +228,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-pub-graph-maintainer-administrative-units:
-    image: lblod/delta-producer-publication-graph-maintainer:0.6.1
+    image: lblod/delta-producer-publication-graph-maintainer:0.7.0
     environment:
       MAX_BODY_SIZE: "50mb"
       JOBS_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
@@ -268,4 +268,65 @@ services:
     logging: *default-logging
 ################################################################################
 # DELTA ADMINISTRATIVE-UNITS: END
+################################################################################
+################################################################################
+# DELTA ORGANIZATIONS: START
+################################################################################
+  delta-producer-bg-jobs-initiator-organizations:
+    image: lblod/delta-producer-background-jobs-initiator:0.3.1
+    environment:
+      JOBS_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      DUMP_FILE_CREATION_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/organizations'
+      INITIAL_PUBLICATION_GRAPH_SYNC_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/organizations'
+      HEALING_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/healingOperation/organizations'
+      CRON_PATTERN_DUMP_JOB: '0 0 4 * * 6' # weekly on saturday
+      CRON_PATTERN_HEALING_JOB: '0 0 4 * * *' # everyday at 4 AM
+      START_INITIAL_SYNC: 'false' # prefer to disable it now. We want to have feeling with how the DB acts.
+    labels:
+      - "logging=true"
+    links:
+      - db:database
+    restart: always
+    logging: *default-logging
+  delta-producer-pub-graph-maintainer-organizations:
+    image: lblod/delta-producer-publication-graph-maintainer:0.7.0
+    environment:
+      MAX_BODY_SIZE: "50mb"
+      JOBS_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      RELATIVE_FILE_PATH: "deltas/organizations"
+      PUBLICATION_GRAPH: 'http://redpencil.data.gift/id/deltas/producer/organizations'
+      HEALING_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/healingOperation/organizations'
+      INITIAL_PUBLICATION_GRAPH_SYNC_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/organizations'
+      QUEUE_POLL_INTERVAL: 3000
+      USE_VIRTUOSO_FOR_EXPENSIVE_SELECTS: "true" # some queries are just too expensive
+      SKIP_MU_AUTH_INITIAL_SYNC: 'true'
+      HEALING_PATCH_GRAPH_BATCH_SIZE: 500
+    volumes:
+      - ./config/delta-producer/organizations:/config
+      - ./data/files/:/share
+    links:
+      - db:database
+      - triplestore:virtuoso
+    restart: always
+    logging: *default-logging
+  delta-producer-json-diff-publisher-organizations:
+    image: lblod/delta-producer-json-diff-file-publisher:0.2.3
+    environment:
+      MAX_BODY_SIZE: "50mb"
+      ERROR_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      RELATIVE_FILE_PATH: "deltas/organizations"
+      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager/organizations"
+      PUBLICATION_GRAPH: 'http://redpencil.data.gift/id/deltas/producer/organizations'
+      DELTA_INTERVAL_MS: 10000
+      PRETTY_PRINT_DIFF_JSON: "true"
+    volumes:
+      - ./data/files:/share
+    labels:
+      - "logging=true"
+    links:
+      - db:database
+    restart: always
+    logging: *default-logging
+################################################################################
+# DELTA ORGANIZATIONS: END
 ################################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,7 +228,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-pub-graph-maintainer-administrative-units:
-    image: lblod/delta-producer-publication-graph-maintainer:0.6.0
+    image: lblod/delta-producer-publication-graph-maintainer:0.6.1
     environment:
       MAX_BODY_SIZE: "50mb"
       JOBS_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,3 +208,19 @@ services:
       - db:database
     restart: always
     logging: *default-logging
+  delta-producer-bg-jobs-initiator-administrative-units:
+    image: lblod/delta-producer-background-jobs-initiator:0.3.1
+    environment:
+      JOBS_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      DUMP_FILE_CREATION_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/administrative-units'
+      INITIAL_PUBLICATION_GRAPH_SYNC_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/administrative-units'
+      HEALING_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/healingOperation/administrative-units'
+      CRON_PATTERN_DUMP_JOB: '0 0 4 * * 6' # weekly on saturday
+      CRON_PATTERN_HEALING_JOB: '0 0 4 * * *' # everyday at 4 AM
+      START_INITIAL_SYNC: 'false' # prefer to disable it now. We want to have feeling with how the DB acts.
+    labels:
+      - "logging=true"
+    links:
+      - db:database
+    restart: always
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,3 +187,9 @@ services:
       - db:database
     restart: always
     logging: *default-logging
+  jobs-controller:
+    image: lblod/job-controller-service:0.7.0
+    links:
+      - db:database
+    volumes:
+      - ./config/jobs-controller/:/config/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,3 +245,21 @@ services:
       - triplestore:virtuoso
     restart: always
     logging: *default-logging
+  delta-producer-json-diff-publisher-administrative-units:
+    image: lblod/delta-producer-json-diff-file-publisher:0.2.3
+    environment:
+      MAX_BODY_SIZE: "50mb"
+      ERROR_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      RELATIVE_FILE_PATH: "deltas/administrative-units"
+      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager/administrative-units"
+      PUBLICATION_GRAPH: 'http://redpencil.data.gift/id/deltas/producer/administrative-units'
+      DELTA_INTERVAL_MS: 10000
+      PRETTY_PRINT_DIFF_JSON: "true"
+    volumes:
+      - ./data/files:/share
+    labels:
+      - "logging=true"
+    links:
+      - db:database
+    restart: always
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     restart: always
     logging: *default-logging
   db:
-    image: semtech/mu-authorization:0.6.0-beta.7
+    image: cecemel/mu-authorization:0.6.0-beta.8
     environment:
       MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
       LOG_OUTGOING_SPARQL_QUERIES: "true"
@@ -92,7 +92,7 @@ services:
     restart: always
     logging: *default-logging
   deltanotifier:
-    image: semtech/mu-delta-notifier:0.1.0
+    image: cecemel/delta-notifier:0.2.0-beta.2
     volumes:
       - ./config/delta:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,3 +224,24 @@ services:
       - db:database
     restart: always
     logging: *default-logging
+  delta-producer-pub-graph-maintainer-administrative-units:
+    image: lblod/delta-producer-publication-graph-maintainer:0.6.0
+    environment:
+      MAX_BODY_SIZE: "50mb"
+      JOBS_GRAPH: "http://mu.semte.ch/graphs/contacthub/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/ChAdmin"
+      RELATIVE_FILE_PATH: "deltas/administrative-units"
+      PUBLICATION_GRAPH: 'http://redpencil.data.gift/id/deltas/producer/administrative-units'
+      HEALING_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/healingOperation/administrative-units'
+      INITIAL_PUBLICATION_GRAPH_SYNC_JOB_OPERATION: 'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/administrative-units'
+      QUEUE_POLL_INTERVAL: 3000
+      USE_VIRTUOSO_FOR_EXPENSIVE_SELECTS: "true" # some queries are just too expensive
+      SKIP_MU_AUTH_INITIAL_SYNC: 'true'
+      HEALING_PATCH_GRAPH_BATCH_SIZE: 500
+    volumes:
+      - ./config/delta-producer/administrative-units:/config
+      - ./data/files/:/share
+    links:
+      - db:database
+      - triplestore:virtuoso
+    restart: always
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,6 +208,9 @@ services:
       - db:database
     restart: always
     logging: *default-logging
+################################################################################
+# DELTA ADMINISTRATIVE-UNITS: START
+################################################################################
   delta-producer-bg-jobs-initiator-administrative-units:
     image: lblod/delta-producer-background-jobs-initiator:0.3.1
     environment:
@@ -263,3 +266,6 @@ services:
       - db:database
     restart: always
     logging: *default-logging
+################################################################################
+# DELTA ADMINISTRATIVE-UNITS: END
+################################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,3 +177,13 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  file:
+    image: semtech/mu-file-service:3.2.0
+    volumes:
+      - ./data/files:/share
+    labels:
+      - "logging=true"
+    links:
+      - db:database
+    restart: always
+    logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,14 +79,17 @@ services:
     restart: always
     logging: *default-logging
   kalliope-api:
-    image: lblod/jsonld-delta-service:0.3.2
+    image: lblod/jsonld-delta-service:0.4.0
     volumes:
       - ./config/kalliope:/config
       - ./data/files:/share
+    links:
+      - db:database
     environment:
       SERVER_PORT: "80"
       LOGGING_LEVEL: "INFO"
       SPARQL_ENDPOINT: "http://db:8890/sparql"
+      LIMIT_SIZE: "10000"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
This PR is an example of how the delta-producers could be injected in the application. 
The focus would be here administrative-units, which could be extremely useful in many of the applications within the loket-realm.
The win would be is that no specific consumers need to be written in the loket realm to ingest the data.

I tried to explain per commit what does what. 

Extra notes:
- To keep it simple, I didn't introduce the reporting service, which I consider useful, as this gives us alerts when things go wrong. So I would recommend to use it too, if this goes to prod.
-  There are multiple background jobs, which follow the jobs model. I didn't integrate the jobs-dashboard, but it might be useful to have this one too, as this provides a GUI on the state of these multiple jobs.
-  The configuration is on what to export is very basic, and may be extended. There are many configuration options, and direct filters possible.
- The main assumption here; the data shared is public. So the endpoints which provide delta json files and dumps are accessible by everyone. There is currently work being done in semantic.works to be able to shield this in a structural way
- Nevertheless on first sight, a lot of the components are compatible with jsonld-delta-service and its security constraints. The extra services introduced here, could be introduced too for the data to share with kalliope. The wins is that you have more control on what is exported and a healing process, something which in practice turns out to be a useful for data-integrity towards third parties. Further, note, that if the building blocks are re-used an extra configuration will be needed.
- I am aware there are still loose ends in all services (e.g. naming), but the basics are covered.