### PR TITLE
Use `date` instead of `datetime` were needed

### DIFF
--- a/config/resources/change-events.json
+++ b/config/resources/change-events.json
@@ -16,7 +16,7 @@
       "class": "org:ChangeEvent",
       "attributes": {
         "date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "dc_terms:date"
         },
         "description": {
@@ -90,7 +90,7 @@
       "class": "http://data.vlaanderen.be/ns/besluit#Besluit",
       "attributes": {
         "publication-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "http://data.europa.eu/eli/ontology#date_publication"
         },
         "document-link": {

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -63,11 +63,11 @@
       "class": "ch:AgentInPositie",
       "attributes": {
         "agent-start-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "ch:startdatum"
         },
         "agent-end-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "ch:eindedatum"
         }
       },
@@ -117,11 +117,11 @@
       "super": ["agents-in-position"],
       "attributes": {
         "start-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "mandaat:start"
         },
         "end-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "mandaat:einde"
         }
       },
@@ -165,7 +165,7 @@
       "super": ["mandatories"],
       "attributes": {
         "expected-end-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "ere:geplandeEinddatumAanstelling"
         },
         "reason-stopped": {
@@ -462,11 +462,11 @@
       "class": "besluit:Bestuursorgaan",
       "attributes": {
         "start-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "mandaat:bindingStart"
         },
         "end-date": {
-          "type": "datetime",
+          "type": "date",
           "predicate": "mandaat:bindingEinde"
         }
       },


### PR DESCRIPTION
If only the date is relevant we should not store it as a `datetime` since that would add timezone information which might cause the date to be displayed incorrectly in the frontend.