### PR TITLE
Temporarily rename the change-event-result organization relationship

### DIFF
--- a/config/migrations/2022/20220125185900-rename-change-event-result-relationship-predicate.sparql
+++ b/config/migrations/2022/20220125185900-rename-change-event-result-relationship-predicate.sparql
@@ -1,0 +1,18 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+    GRAPH ?g {
+      ?changeEventResult org:organization ?organization .
+    }
+} INSERT {
+    GRAPH ?g {
+      ?changeEventResult ext:resultingOrganization ?organization .
+    }
+} WHERE {
+  GRAPH ?g {
+    ?changeEventResult a <http://lblod.data.gift/vocabularies/organisatie/VeranderingsgebeurtenisResultaat> ;
+            org:organization ?organization .
+  }
+}

--- a/config/resources/change-events.json
+++ b/config/resources/change-events.json
@@ -58,7 +58,7 @@
       "attributes": {},
       "relationships": {
         "resulting-organization": {
-          "predicate": "org:organization",
+          "predicate": "ext:resultingOrganization",
           "target": "organizations",
           "cardinality": "one"
         },

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -311,7 +311,7 @@
           "inverse": true
         },
         "change-event-results": {
-          "predicate": "org:organization",
+          "predicate": "ext:resultingOrganization",
           "target": "change-event-results",
           "cardinality": "many",
           "inverse": true


### PR DESCRIPTION
This relationship uses the same `org:organization` predicate that is also used for the local involvements relationship. When querying for local involvements data when an organization also has change events data,  mu-cl-resources receives the change events data instead and runs into errors. This is likely a bug in the micro service itself. Renaming the predicate is a quick workaround so we have more time to find the real solution for the problem without a broken app.