### PR TITLE
Optimize query performance - avoid thread kill

### DIFF
--- a/config/dev-migrations/20210910120000-pseudonimize-UPDATE-BEFORE-RUNNING.sparql.disabled
+++ b/config/dev-migrations/20210910120000-pseudonimize-UPDATE-BEFORE-RUNNING.sparql.disabled
@@ -42,6 +42,7 @@ DELETE {
       ?address adres:gemeentenaam ?gemeente_s.
     }
 } WHERE {
+  VALUES ?g { <http://mu.semte.ch/graphs/organisatieportaal> <http://redpencil.data.gift/id/deltas/producer/organizations>}
   GRAPH ?g {
     BIND("REPLACE_ME_WITH_A_RANDOM_STRING" AS ?salt).
     ?person a person:Person.


### PR DESCRIPTION
This prevents Virtuoso cancelling queries which take too much time