### PR TITLE
chore: bump delta-notifier service to most recent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 ## Unreleased
+### Backend
+- Bump delta-notifier service to most recent version [OP-3190]
+### Deploy notes
+```
+drc pull deltanotifier; drc up -d deltanotifier
+```
 
 ## v1.33.2 (2025-06-20)
 ### Backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
     restart: always
     logging: *default-logging
   deltanotifier:
-    image: cecemel/delta-notifier:0.2.0-beta.2
+    image: semtech/mu-delta-notifier:0.4.0
     volumes:
       - ./config/delta:/config
     labels:


### PR DESCRIPTION
Updates the delta-notifier service to it most recently released version.

More recent versions should deal better with services that have to receive
deltas being down. This can help with the occasionally reported issue in which
organisation's status changes are not timely reflected in the results from
mu-search (see related ticket for more details.).

## Related tickets
- OP-3190