### PR TITLE
OP-3766: added updated bestuurseenheden query to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+- added administrativeUnits report with strekking [OP-3766]
+
+### Deploy notes
+```
+drc restart report-generation
+```
+
 ## 1.39.0 (2026-04-02)
 - Add KBO organizations report to report generation service [OP-3738]
 - Add organizations detail report (addresses and contact info) to report generation service [OP-3738]

--- a/config/reports/administrative-units-report.js
+++ b/config/reports/administrative-units-report.js
@@ -3,7 +3,7 @@ import { PREFIXES } from "./utils";
 
 export default {
   cronPattern: "0 00 1 * * *",
-  name: "administrative units",
+  name: "administrativeUnits",
   execute: async () => {
     const reportData = {
       title: "administrative units",

--- a/config/reports/administrative-units-report.js
+++ b/config/reports/administrative-units-report.js
@@ -1,0 +1,187 @@
+import { generateReportFromData, batchedQuery } from "../helpers.js";
+import { PREFIXES } from "./utils";
+
+export default {
+  cronPattern: "0 00 1 * * *",
+  name: "administrative units",
+  execute: async () => {
+    const reportData = {
+      title: "administrative units",
+      description: "List of the administrative units",
+      filePrefix: "exports/administrative-units",
+    };
+
+    console.log("Generating administrative units report");
+
+    const queryString = `
+    ${PREFIXES}
+    
+    SELECT DISTINCT
+      ?Bestuurseenheid
+      ?Classificatie
+      ?Status
+      ?KBO_nr
+      ?OVO_nr
+      ?Sharepoint_id
+      ?NIS_code
+      ?Regio
+      ?Provincie
+      ?Straat
+      ?Huisnummer
+      ?Busnummer
+      ?Postcode
+      ?Gemeente
+      (STR(?GrensoverschrijdendBoolean) AS ?Grensoverschrijdend)
+      ?TypeEredienst
+      ?BestuurseenheidURI
+      ?Stekking
+    {
+      VALUES ?type {
+        besluit:Bestuurseenheid
+        ere:BestuurVanDeEredienst
+        org:Organization
+        ere:EredienstBestuurseenheid
+        ere:CentraalBestuurVanDeEredienst
+      }
+    
+      ?BestuurseenheidURI 
+        a ?type.
+      OPTIONAL { ?BestuurseenheidURI skos:prefLabel ?Bestuurseenheid . }
+      OPTIONAL { ?BestuurseenheidURI org:classification/skos:prefLabel ?Classificatie. }
+    
+      OPTIONAL {
+        ?BestuurseenheidURI besluit:werkingsgebied ?werkingsgebiedURI.
+        ?werkingsgebiedURI rdfs:label ?werkingsgebied.
+        OPTIONAL {
+          ?werkingsgebiedURI geo:sfWithin ?regionURI.
+          ?regionURI 
+            ext:werkingsgebiedNiveau "Referentieregio"@nl;
+            rdfs:label ?langRegio.
+        }
+        OPTIONAL {
+          ?werkingsgebiedURI skos:exactMatch ?nisArea.
+            ?nisArea skos:inScheme ?NISCodeScheme;
+            skos:notation ?NIS_code.
+    
+          FILTER (?NISCodeScheme IN ( <http://vocab.belgif.be/auth/refnis2019>, <http://vocab.belgif.be/auth/refnis2025>))
+        }
+      }
+      OPTIONAL {
+        ?BestuurseenheidURI org:hasPrimarySite/organisatie:bestaatUit ?address .
+        ?address adres:gemeentenaam ?Gemeente .
+    
+        ?municipalityRegio a besluit:Bestuurseenheid ;
+          skos:prefLabel ?Gemeente ;
+          org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> ;
+          besluit:werkingsgebied ?werkingsgebiedRegioURI.
+    
+          ?werkingsgebiedRegioURI geo:sfWithin ?regioViaAddressURI.
+          ?regioViaAddressURI 
+            ext:werkingsgebiedNiveau "Referentieregio"@nl;
+            rdfs:label ?langRegioViaAddress.
+      }
+    
+      BIND(IF(BOUND(?langRegio) && strlen(?langRegio)>0, str(?langRegio), str(?langRegioViaAddress)) AS ?Regio)
+    
+      OPTIONAL { ?BestuurseenheidURI regorg:orgStatus/skos:prefLabel ?Status. }
+      OPTIONAL { ?BestuurseenheidURI ere:typeEredienst ?typeEredienstUri.
+        OPTIONAL { ?typeEredienstUri skos:prefLabel ?TypeEredienst. }
+      }
+      OPTIONAL { ?BestuurseenheidURI ere:grensoverschrijdend ?GrensoverschrijdendBoolean. }
+      OPTIONAL { ?BestuurseenheidURI org:hasPrimarySite/organisatie:bestaatUit ?address .
+        OPTIONAL { ?address locn:thoroughfare ?Straat }
+        OPTIONAL { ?address adres:Adresvoorstelling.huisnummer ?Huisnummer . }
+        OPTIONAL { ?address adres:Adresvoorstelling.busnummer ?Busnummer . }
+        OPTIONAL { ?address locn:postCode ?Postcode . }
+        OPTIONAL { ?address adres:gemeentenaam ?Gemeente . }
+        OPTIONAL { ?address locn:adminUnitL2 ?Provincie . }
+        OPTIONAL { ?address adres:land ?Land . }
+      }
+      OPTIONAL {
+        ?BestuurseenheidURI adms:identifier ?kbo_identifier .
+        ?kbo_identifier
+          skos:notation ?kbo_notation;
+          generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator ?KBO_nr.
+        FILTER (str(?kbo_notation) = "KBO nummer")
+      }
+      OPTIONAL {
+        ?BestuurseenheidURI adms:identifier ?ovo_identifier .
+        ?ovo_identifier
+          skos:notation ?ovo_notation;
+          generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator ?OVO_nr.
+        FILTER (str(?ovo_notation) = "OVO-nummer")
+      }
+      OPTIONAL {
+        ?BestuurseenheidURI adms:identifier ?sp_identifier .
+        ?sp_identifier
+          skos:notation ?sp_notation;
+          generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator ?Sharepoint_id.
+        FILTER (str(?sp_notation) = "SharePoint identificator")
+      }
+      OPTIONAL {
+        ?changeEvent org:resultingOrganization ?BestuurseenheidURI;
+          ch:typeWijziging <http://lblod.data.gift/concepts/e4c3d1ef-a34d-43b0-a18c-f4e60e2c8af3>.
+        <http://lblod.data.gift/concepts/e4c3d1ef-a34d-43b0-a18c-f4e60e2c8af3> skos:prefLabel ?stadsTitel
+      }
+      OPTIONAL { ?BestuurseenheidURI ere:denominatie ?Stekking. }
+    } ORDER BY DESC(?Classificatie) ?Bestuurseenheid
+    `;
+
+    const queryResponse = await batchedQuery(queryString);
+
+    const data = queryResponse.results.bindings.map((row) => ({
+        Bestuurseenheid: getSafeValue(row, "Bestuurseenheid"),
+        Classificatie: getSafeValue(row, "Classificatie"),
+        Status: getSafeValue(row, "Status"),
+        KBO_nr: getSafeValue(row, "KBO_nr"),
+        OVO_nr: getSafeValue(row, "OVO_nr"),
+        Sharepoint_id: getSafeValue(row, "Sharepoint_id"),
+        NIS_code: getSafeValue(row, "NIS_code"),
+        Regio: getSafeValue(row, "Regio"),
+        Provincie: getSafeValue(row, "Provincie"),
+        Straat: getSafeValue(row, "Straat"),
+        Huisnummer: getSafeValue(row, "Huisnummer"),
+        Busnummer: getSafeValue(row, "Busnummer"),
+        Postcode: getSafeValue(row, "Postcode"),
+        Gemeente: getSafeValue(row, "Gemeente"),
+        Grensoverschrijdend: getSafeValue(row, "Grensoverschrijdend"),
+        TypeEredienst: getSafeValue(row, "TypeEredienst"),
+        BestuurseenheidURI: getSafeValue(row, "BestuurseenheidURI"),
+        Stekking: getSafeValue(row, "Stekking"),
+    }));
+
+    await generateReportFromData(
+        data,
+        [
+          "Bestuurseenheid",
+          "Classificatie",
+          "Status",
+          "KBO_nr",
+          "OVO_nr",
+          "Sharepoint_id",
+          "NIS_code",
+          "Regio",
+          "Provincie",
+          "Straat",
+          "Huisnummer",
+          "Busnummer",
+          "Postcode",
+          "Gemeente",
+          "Grensoverschrijdend",
+          "TypeEredienst",
+          "BestuurseenheidURI",
+          "Stekking",
+        ],
+        reportData,
+    );
+  },
+};
+
+function getSafeValue(entry, property) {
+  return entry[property] ? wrapInQuote(entry[property].value) : null;
+}
+
+// Some values might contain commas; wrapping them in escapes quotes doesn't disrupt the columns.
+function wrapInQuote(value) {
+  return `\"${value}\"`;
+}

--- a/config/reports/index.js
+++ b/config/reports/index.js
@@ -3,6 +3,7 @@ import RelatedOrganizationsReport from './related-organizations-report'
 import KboOrganizationsReport from './kbo-organizations-report'
 import OrganizationsDetailReport from './organizations-detail-report'
 import OrganizationsPlatformReport from './organizations-platform-report'
+import AdministrativeUnitsReport from "./administrative-units-report";
 
 export default [
   OrganizationsReport,
@@ -10,4 +11,5 @@ export default [
   KboOrganizationsReport,
   OrganizationsDetailReport,
   OrganizationsPlatformReport,
+  AdministrativeUnitsReport
 ];

--- a/config/reports/utils.js
+++ b/config/reports/utils.js
@@ -26,4 +26,5 @@ export const PREFIXES = `
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
   PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+  PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 `;


### PR DESCRIPTION
- Added the bestuurseenheden query (https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/-M_5cpNQ4inMjiC5hhyJ/data-quality/sparql-queries#bestuurseenheden) to report config.
- Updated this query with strekking

TO TEST:
- rsync with OP data
- start OP stack
- execute command: docker compose exec report-generation curl -X POST localhost/reports   -H "Content-Type: application/json"   -d '{"data":{"attributes":{"reportName":"administrative units"}}}'
- check if report is generated and strekking is added.