### PR TITLE
[OP-3757]: cleanup local involvement of oud heverlee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+- Cleanup local involvement for oud heverlee [OP-3757]
+
+### Deploy notes
+```
+drc restart migrations && drc logs -ft --tail=200 migrations
+```
+
 ## 1.39.0 (2026-04-02)
 - Add KBO organizations report to report generation service [OP-3738]
 - Add organizations detail report (addresses and contact info) to report generation service [OP-3738]

--- a/config/migrations/2026/20260414100057-delete-local-involvement-oud-heverlee.sparql
+++ b/config/migrations/2026/20260414100057-delete-local-involvement-oud-heverlee.sparql
@@ -1,0 +1,35 @@
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/a648cf4f6e94d3ea0b0ed32b73b75dd9> ?p ?o.
+  }
+}
+
+;
+
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/bestuurseenheden/c648ea5d12626ee3364a02debb223908a71e68f53d69a7a7136585b58a083e77> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a648cf4f6e94d3ea0b0ed32b73b75dd9>.
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+      ?localInvolvementOudHeverlee <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> ?percentage.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?localInvolvementOudHeverlee <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100.
+  }
+}
+WHERE {
+  BIND(<http://mu.semte.ch/graphs/worship-service> AS ?g)
+  GRAPH ?g {
+    ?localInvolvementOudHeverlee <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> ?percentage.
+  }
+  VALUES ?localInvolvementOudHeverlee {
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/3c8696890fb0bb865a798923acf58dcf>
+  }
+}


### PR DESCRIPTION
## ID

OP-3757

## Description

Remove 1 local involvement for worship service 'oud heverlee', update percentage of the remaining to 100%.

## How test

Setup with dev/qa data and run migration, verify that the worship serve only has 1 local involvement left with 100%.