### PR TITLE
Feature/vlaams gewest

### DIFF
--- a/config/migrations/2026/20260417120000-feat--add-vlaams-gewest-werkingsgebied/20260417120001-create-vlaams-gewest-location.sparql
+++ b/config/migrations/2026/20260417120000-feat--add-vlaams-gewest-werkingsgebied/20260417120001-create-vlaams-gewest-location.sparql
@@ -1,0 +1,25 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?vlaamsGewest a prov:Location ;
+                  mu:uuid ?uuid ;
+                  rdfs:label "Vlaams Gewest" ;
+                  ext:werkingsgebiedNiveau "Gewest" ;
+                  skos:exactMatch <http://vocab.belgif.be/auth/refnis2025/2000> ,
+                                  <http://vocab.belgif.be/auth/refnis2019/2000> .
+  }
+} WHERE {
+  BIND(SHA256(CONCAT("Werkingsgebied for Vlaams Gewest")) AS ?uuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/werkingsgebieden/", STR(?uuid))) AS ?vlaamsGewest)
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?existing ext:werkingsgebiedNiveau "Gewest" ;
+                rdfs:label "Vlaams Gewest" .
+    }
+  }
+}

--- a/config/migrations/2026/20260417120000-feat--add-vlaams-gewest-werkingsgebied/20260417120002-link-flemish-werkingsgebieden-to-vlaams-gewest.sparql
+++ b/config/migrations/2026/20260417120000-feat--add-vlaams-gewest-werkingsgebied/20260417120002-link-flemish-werkingsgebieden-to-vlaams-gewest.sparql
@@ -1,0 +1,85 @@
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX geo:     <http://www.opengis.net/ont/geosparql#>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX org:     <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+# 1) Link the 5 Flemish province werkingsgebieden themselves to Vlaams Gewest
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?provWg geo:sfWithin ?vlaamsGewest .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?vlaamsGewest a prov:Location ;
+                  ext:werkingsgebiedNiveau "Gewest" ;
+                  rdfs:label "Vlaams Gewest" .
+  }
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?province a besluit:Bestuurseenheid ;
+              org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
+  }
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?province besluit:werkingsgebied ?provWg .
+  }
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?provWg geo:sfWithin ?vlaamsGewest .
+    }
+  }
+} ;
+
+# 2) Link Flemish municipality werkingsgebieden to Vlaams Gewest
+#    Selector: any Gemeente-level location whose sfWithin is a werkingsgebied
+#    belonging to a Bestuurseenheid classified as Provincie (i.e. a Flemish province).
+#    Brussels has no provinces, and there are no Waals-Gewest provinces in OP,
+#    so "classified as Provincie" == "Flemish province".
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?munWg geo:sfWithin ?vlaamsGewest .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?vlaamsGewest a prov:Location ;
+                  ext:werkingsgebiedNiveau "Gewest" ;
+                  rdfs:label "Vlaams Gewest" .
+    ?munWg a prov:Location ;
+           ext:werkingsgebiedNiveau "Gemeente" ;
+           geo:sfWithin ?provWg .
+  }
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?province a besluit:Bestuurseenheid ;
+              org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
+  }
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?province besluit:werkingsgebied ?provWg .
+  }
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?munWg geo:sfWithin ?vlaamsGewest .
+    }
+  }
+} ;
+
+# 3) Link all District and Referentieregio werkingsgebieden to Vlaams Gewest
+#    All districts and referentieregios in the data are Flemish by scope;
+#    no further filtering required.
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?wg geo:sfWithin ?vlaamsGewest .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?vlaamsGewest a prov:Location ;
+                  ext:werkingsgebiedNiveau "Gewest" ;
+                  rdfs:label "Vlaams Gewest" .
+    ?wg a prov:Location ; ext:werkingsgebiedNiveau ?niveau .
+    VALUES ?niveau { "District" "Referentieregio" }
+  }
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?wg geo:sfWithin ?vlaamsGewest .
+    }
+  }
+}


### PR DESCRIPTION
Extends werkiingsgebieden hierarchy [OP-3755]

Differentiate between Flemish and Brussels communes by checking the werkingsgebieden hierarchy.

```
# 1. Full stack up, wait for migrations to finish
drc up -d triplestore migrations
drc logs -f migrations | grep 'All migrations'

# 2. Kick off healing + dump-file creation
drc up -d db deltanotifier jobs-controller \
  delta-producer-background-jobs-initiator \
  delta-producer-publication-graph-maintainer \
  delta-producer-dump-file-publisher kalliope-api

drc exec delta-producer-background-jobs-initiator \
  curl -sS -X POST http://localhost/organizations/healing-jobs
# wait until status = success, then:
drc exec delta-producer-background-jobs-initiator \
  curl -sS -X POST http://localhost/organizations/dump-publication-graph-jobs
# wait until status = success
drc exec kalliope-api curl -sS http://localhost/consolidated > /tmp/kalliope.json
```

expected:

Any Flemish commune has a werkingsgebied, that werkingsgebied has `geo:sfWithin` `http://data.lblod.info/id/werkingsgebieden/bb588c8b5cf8c25cf88b21773c21d8bcef7af0f247e18b6535a4aaa07fce5243`
```
{
  "@id": "http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169",
  "@type": "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
  "http://www.w3.org/2004/02/skos/core#prefLabel": "Hasselt",
  "http://www.w3.org/ns/org#classification": {
    "@id": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001"
  },
  "http://data.vlaanderen.be/ns/besluit#werkingsgebied": {
    "@id": "http://data.lblod.info/id/werkingsgebieden/e55336a3ecbae33f21e595458ba93eeeb0fa4390626622884d4d32523d0e0033"
  }
}

...

{
  "@id": "http://data.lblod.info/id/werkingsgebieden/e55336a3ecbae33f21e595458ba93eeeb0fa4390626622884d4d32523d0e0033",
  "@type": "http://www.w3.org/ns/prov#Location",
  "http://www.w3.org/2000/01/rdf-schema#label": "Hasselt",
  "http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau": "Gemeente",
  "http://www.w3.org/2004/02/skos/core#exactMatch": {
    "@id": "http://vocab.belgif.be/auth/refnis2025/71072"
  },
  "http://www.opengis.net/ont/geosparql#sfWithin": [
    { "@id": "http://data.lblod.info/id/werkingsgebieden/b6868be9ca6881b1020e6cff8d431531a1cff64b39dc92646a5173b3ee144516" },
   { "@id": "http://data.lblod.info/id/werkingsgebieden/bb588c8b5cf8c25cf88b21773c21d8bcef7af0f247e18b6535a4aaa07fce5243" },
    { "@id": "http://data.lblod.info/id/werkingsgebieden/1e96dea77a67bc6efb5cb8746de22e25" },
    { "@id": "http://data.lblod.info/id/werkingsgebieden/c9f1b380-fdd4-11f0-8b23-230af7bf3856" },
    { "@id": "http://data.lblod.info/id/werkingsgebieden/737cc7c08419d7d784942b92222cf1958fd1ba9b30066b009fa0ff27e5656c6d" }
  ]
}
```

319 Flemish matched, 20 non-Flemish (19 Brussels + 1 testgemeente) excluded.
