### PR TITLE
Added juridische vorm + change-event

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -219,7 +219,6 @@
   ("code:BedienaarCriteriumBewijsstuk" -> _)
   ("code:EredienstBeroepen" -> _)
   ("code:Rechtsvormtype" -> _)
-  ("ext:LegalForm" -> _)
   ("prov:Location" -> _))
 
 (define-graph shared ("http://mu.semte.ch/graphs/shared")

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -219,6 +219,7 @@
   ("code:BedienaarCriteriumBewijsstuk" -> _)
   ("code:EredienstBeroepen" -> _)
   ("code:Rechtsvormtype" -> _)
+  ("ext:LegalForm" -> _)
   ("prov:Location" -> _))
 
 (define-graph shared ("http://mu.semte.ch/graphs/shared")

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -95,6 +95,10 @@ defmodule Dispatcher do
     Proxy.forward(conn, path, "http://cache/registered-organization-classification-codes/")
   end
 
+  match "/legal-form-codes/*path", %{accept: [:json], layer: :api} do
+      Proxy.forward(conn, path, "http://cache/legal-form-codes/")
+    end
+
   match "/worship-administrative-units/*path", %{accept: [:json], layer: :api} do
     Proxy.forward(conn, path, "http://cache/worship-administrative-units/")
   end

--- a/config/migrations/2026/20260615120000-add-legal-forms-codelist.graph
+++ b/config/migrations/2026/20260615120000-add-legal-forms-codelist.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2026/20260615120000-add-legal-forms-codelist.ttl
+++ b/config/migrations/2026/20260615120000-add-legal-forms-codelist.ttl
@@ -1,0 +1,188 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix conceptscheme: <http://data.vlaanderen.be/id/conceptscheme/> .
+@prefix concept: <http://data.vlaanderen.be/id/concept/LegalFormCode/> .
+
+# Concept Scheme for Legal Forms
+conceptscheme:LegalFormCode
+  rdf:type skos:ConceptScheme ;
+  skos:prefLabel "Juridische vorm" .
+
+# Legal Form Codes
+concept:4a55b679-e4c7-4014-a0b8-3d6762e0225f
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "4a55b679-e4c7-4014-a0b8-3d6762e0225f" ;
+  skos:prefLabel "Stad / gemeente" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:e87b0707-1f9c-4577-8918-023e60974d2f
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "e87b0707-1f9c-4577-8918-023e60974d2f" ;
+  skos:prefLabel "Openbaar centrum voor maatschappelijk welzijn" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:fa7b4356-6e67-4d3a-9256-72922a12227a
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "fa7b4356-6e67-4d3a-9256-72922a12227a" ;
+  skos:prefLabel "Provinciale overheid" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:37e78d58-ab28-4047-8d23-4f2c09707c22
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "37e78d58-ab28-4047-8d23-4f2c09707c22" ;
+  skos:prefLabel "Autonoom gemeentebedrijf" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:5a015434-4917-4124-a8ad-7f80d5300952
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "5a015434-4917-4124-a8ad-7f80d5300952" ;
+  skos:prefLabel "Autonoom provinciebedrijf" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:107b192a-44e4-4d4b-aba7-e41aa6cc7f69
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "107b192a-44e4-4d4b-aba7-e41aa6cc7f69" ;
+  skos:prefLabel "Projectvereniging" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:960f8bb1-ea5d-40d7-bbf4-dbc0794afd26
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "960f8bb1-ea5d-40d7-bbf4-dbc0794afd26" ;
+  skos:prefLabel "Dienstverlenende vereniging (Vlaams Gewest)" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:574a4cfb-7958-463a-9f4c-d9c4b250847c
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "574a4cfb-7958-463a-9f4c-d9c4b250847c" ;
+  skos:prefLabel "Opdrachthoudende vereniging (Vlaams Gewest)" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:c28b64ce-bb6c-4f8f-b03f-51dc09ae6748
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "c28b64ce-bb6c-4f8f-b03f-51dc09ae6748" ;
+  skos:prefLabel "Lokale politiezone" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:75b075c8-1076-4ea3-9bc3-366f6cf866f4
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "75b075c8-1076-4ea3-9bc3-366f6cf866f4" ;
+  skos:prefLabel "Hulpverleningszone" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:dbdd09f3-55b1-48bc-ac51-2c87f951860a
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "dbdd09f3-55b1-48bc-ac51-2c87f951860a" ;
+  skos:prefLabel "Vereniging zonder winstoogmerk" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:925fbdb3-4693-4dcf-b75e-0a98985b1785
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "925fbdb3-4693-4dcf-b75e-0a98985b1785" ;
+  skos:prefLabel "Internationale vereniging zonder winstoogmerk" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:f25de736-bbc3-4e73-b401-5ee0b277f5f8
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "f25de736-bbc3-4e73-b401-5ee0b277f5f8" ;
+  skos:prefLabel "Private stichting" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:9f578b10-255a-4403-ab4c-5d4415c30a0a
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "9f578b10-255a-4403-ab4c-5d4415c30a0a" ;
+  skos:prefLabel "Stichting van openbaar nut" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:30fb3516-fc48-453b-b1f6-a571d149ca3a
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "30fb3516-fc48-453b-b1f6-a571d149ca3a" ;
+  skos:prefLabel "Maatschap" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:7e31d057-fde3-47f3-ad89-3efd9e22ab08
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "7e31d057-fde3-47f3-ad89-3efd9e22ab08" ;
+  skos:prefLabel "Vennootschap onder firma" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:cab6c3f9-aeee-48f0-88eb-c404310870ad
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "cab6c3f9-aeee-48f0-88eb-c404310870ad" ;
+  skos:prefLabel "Commanditaire vennootschap" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:8aa6149a-0916-42ed-a907-f760c0720527
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "8aa6149a-0916-42ed-a907-f760c0720527" ;
+  skos:prefLabel "Besloten Vennootschap" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:e85bdc30-a69f-48f2-bc08-d32b640b1730
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "e85bdc30-a69f-48f2-bc08-d32b640b1730" ;
+  skos:prefLabel "Naamloze vennootschap" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:f35352d5-9454-4561-916a-f5f6459bc92b
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "f35352d5-9454-4561-916a-f5f6459bc92b" ;
+  skos:prefLabel "Coöperatieve vennootschap" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:205d4e7b-d6cc-4534-8336-7fae98dc139e
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "205d4e7b-d6cc-4534-8336-7fae98dc139e" ;
+  skos:prefLabel "Organisme voor de Financiering van Pensioenen" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:aa2590a0-b6de-4cba-982c-27d70553b17e
+  rdf:type ext:LegalForm ;
+  rdf:type skos:Concept ;
+  mu:uuid "aa2590a0-b6de-4cba-982c-27d70553b17e" ;
+  skos:prefLabel "Andere" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .

--- a/config/migrations/2026/20260615120000-add-legal-forms-codelist.ttl
+++ b/config/migrations/2026/20260615120000-add-legal-forms-codelist.ttl
@@ -4,6 +4,7 @@
 @prefix code: <http://lblod.data.gift/vocabularies/organisatie/> .
 @prefix conceptscheme: <http://data.vlaanderen.be/id/conceptscheme/> .
 @prefix concept: <http://data.vlaanderen.be/id/concept/LegalFormCode/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
 
 # Concept Scheme for Legal Forms
 conceptscheme:LegalFormCode
@@ -16,6 +17,7 @@ concept:4a55b679-e4c7-4014-a0b8-3d6762e0225f
   rdf:type skos:Concept ;
   mu:uuid "4a55b679-e4c7-4014-a0b8-3d6762e0225f" ;
   skos:prefLabel "Stad / gemeente" ;
+  ext:order 1 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -24,6 +26,7 @@ concept:e87b0707-1f9c-4577-8918-023e60974d2f
   rdf:type skos:Concept ;
   mu:uuid "e87b0707-1f9c-4577-8918-023e60974d2f" ;
   skos:prefLabel "Openbaar centrum voor maatschappelijk welzijn" ;
+  ext:order 2 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -32,6 +35,7 @@ concept:fa7b4356-6e67-4d3a-9256-72922a12227a
   rdf:type skos:Concept ;
   mu:uuid "fa7b4356-6e67-4d3a-9256-72922a12227a" ;
   skos:prefLabel "Provinciale overheid" ;
+  ext:order 3 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -40,6 +44,7 @@ concept:37e78d58-ab28-4047-8d23-4f2c09707c22
   rdf:type skos:Concept ;
   mu:uuid "37e78d58-ab28-4047-8d23-4f2c09707c22" ;
   skos:prefLabel "Autonoom gemeentebedrijf" ;
+  ext:order 4 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -48,6 +53,7 @@ concept:5a015434-4917-4124-a8ad-7f80d5300952
   rdf:type skos:Concept ;
   mu:uuid "5a015434-4917-4124-a8ad-7f80d5300952" ;
   skos:prefLabel "Autonoom provinciebedrijf" ;
+  ext:order 5 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -56,6 +62,7 @@ concept:107b192a-44e4-4d4b-aba7-e41aa6cc7f69
   rdf:type skos:Concept ;
   mu:uuid "107b192a-44e4-4d4b-aba7-e41aa6cc7f69" ;
   skos:prefLabel "Projectvereniging" ;
+  ext:order 6 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -64,6 +71,7 @@ concept:960f8bb1-ea5d-40d7-bbf4-dbc0794afd26
   rdf:type skos:Concept ;
   mu:uuid "960f8bb1-ea5d-40d7-bbf4-dbc0794afd26" ;
   skos:prefLabel "Dienstverlenende vereniging (Vlaams Gewest)" ;
+  ext:order 7 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -72,6 +80,7 @@ concept:574a4cfb-7958-463a-9f4c-d9c4b250847c
   rdf:type skos:Concept ;
   mu:uuid "574a4cfb-7958-463a-9f4c-d9c4b250847c" ;
   skos:prefLabel "Opdrachthoudende vereniging (Vlaams Gewest)" ;
+  ext:order 8 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -80,6 +89,7 @@ concept:c28b64ce-bb6c-4f8f-b03f-51dc09ae6748
   rdf:type skos:Concept ;
   mu:uuid "c28b64ce-bb6c-4f8f-b03f-51dc09ae6748" ;
   skos:prefLabel "Lokale politiezone" ;
+  ext:order 9 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -88,6 +98,7 @@ concept:75b075c8-1076-4ea3-9bc3-366f6cf866f4
   rdf:type skos:Concept ;
   mu:uuid "75b075c8-1076-4ea3-9bc3-366f6cf866f4" ;
   skos:prefLabel "Hulpverleningszone" ;
+  ext:order 10 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -96,6 +107,7 @@ concept:dbdd09f3-55b1-48bc-ac51-2c87f951860a
   rdf:type skos:Concept ;
   mu:uuid "dbdd09f3-55b1-48bc-ac51-2c87f951860a" ;
   skos:prefLabel "Vereniging zonder winstoogmerk" ;
+  ext:order 11 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -104,6 +116,7 @@ concept:925fbdb3-4693-4dcf-b75e-0a98985b1785
   rdf:type skos:Concept ;
   mu:uuid "925fbdb3-4693-4dcf-b75e-0a98985b1785" ;
   skos:prefLabel "Internationale vereniging zonder winstoogmerk" ;
+  ext:order 12 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -112,6 +125,7 @@ concept:f25de736-bbc3-4e73-b401-5ee0b277f5f8
   rdf:type skos:Concept ;
   mu:uuid "f25de736-bbc3-4e73-b401-5ee0b277f5f8" ;
   skos:prefLabel "Private stichting" ;
+  ext:order 13 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -120,6 +134,7 @@ concept:9f578b10-255a-4403-ab4c-5d4415c30a0a
   rdf:type skos:Concept ;
   mu:uuid "9f578b10-255a-4403-ab4c-5d4415c30a0a" ;
   skos:prefLabel "Stichting van openbaar nut" ;
+  ext:order 14 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -128,6 +143,7 @@ concept:30fb3516-fc48-453b-b1f6-a571d149ca3a
   rdf:type skos:Concept ;
   mu:uuid "30fb3516-fc48-453b-b1f6-a571d149ca3a" ;
   skos:prefLabel "Maatschap" ;
+  ext:order 15 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -136,6 +152,7 @@ concept:7e31d057-fde3-47f3-ad89-3efd9e22ab08
   rdf:type skos:Concept ;
   mu:uuid "7e31d057-fde3-47f3-ad89-3efd9e22ab08" ;
   skos:prefLabel "Vennootschap onder firma" ;
+  ext:order 16 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -144,6 +161,7 @@ concept:cab6c3f9-aeee-48f0-88eb-c404310870ad
   rdf:type skos:Concept ;
   mu:uuid "cab6c3f9-aeee-48f0-88eb-c404310870ad" ;
   skos:prefLabel "Commanditaire vennootschap" ;
+  ext:order 17 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -152,6 +170,7 @@ concept:8aa6149a-0916-42ed-a907-f760c0720527
   rdf:type skos:Concept ;
   mu:uuid "8aa6149a-0916-42ed-a907-f760c0720527" ;
   skos:prefLabel "Besloten Vennootschap" ;
+  ext:order 18 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -160,6 +179,7 @@ concept:e85bdc30-a69f-48f2-bc08-d32b640b1730
   rdf:type skos:Concept ;
   mu:uuid "e85bdc30-a69f-48f2-bc08-d32b640b1730" ;
   skos:prefLabel "Naamloze vennootschap" ;
+  ext:order 19 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -168,6 +188,7 @@ concept:f35352d5-9454-4561-916a-f5f6459bc92b
   rdf:type skos:Concept ;
   mu:uuid "f35352d5-9454-4561-916a-f5f6459bc92b" ;
   skos:prefLabel "Coöperatieve vennootschap" ;
+  ext:order 20 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -176,14 +197,7 @@ concept:205d4e7b-d6cc-4534-8336-7fae98dc139e
   rdf:type skos:Concept ;
   mu:uuid "205d4e7b-d6cc-4534-8336-7fae98dc139e" ;
   skos:prefLabel "Organisme voor de Financiering van Pensioenen" ;
-  skos:topConceptOf conceptscheme:LegalFormCode ;
-  skos:inScheme conceptscheme:LegalFormCode .
-
-concept:aa2590a0-b6de-4cba-982c-27d70553b17e
-  rdf:type code:Rechtsvormtype ;
-  rdf:type skos:Concept ;
-  mu:uuid "aa2590a0-b6de-4cba-982c-27d70553b17e" ;
-  skos:prefLabel "Andere" ;
+  ext:order 21 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -192,6 +206,7 @@ concept:b4f2c3d5-8a7e-4f1b-9c2d-3e5f6a7b8c9d
   rdf:type skos:Concept ;
   mu:uuid "b4f2c3d5-8a7e-4f1b-9c2d-3e5f6a7b8c9d" ;
   skos:prefLabel "Autonome verzorgingsinstelling" ;
+  ext:order 22 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -200,6 +215,7 @@ concept:c7d8e9f0-1a2b-4c5d-6e7f-8a9b0c1d2e3f
   rdf:type skos:Concept ;
   mu:uuid "c7d8e9f0-1a2b-4c5d-6e7f-8a9b0c1d2e3f" ;
   skos:prefLabel "Welzijnsvereniging" ;
+  ext:order 23 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .
 
@@ -208,5 +224,15 @@ concept:d1e2f3a4-5b6c-7d8e-9f0a-1b2c3d4e5f6a
   rdf:type skos:Concept ;
   mu:uuid "d1e2f3a4-5b6c-7d8e-9f0a-1b2c3d4e5f6a" ;
   skos:prefLabel "Geen rechtspersoonlijkheid" ;
+  ext:order 24 ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:aa2590a0-b6de-4cba-982c-27d70553b17e
+  rdf:type code:Rechtsvormtype ;
+  rdf:type skos:Concept ;
+  mu:uuid "aa2590a0-b6de-4cba-982c-27d70553b17e" ;
+  skos:prefLabel "Andere" ;
+  ext:order 25 ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .

--- a/config/migrations/2026/20260615120000-add-legal-forms-codelist.ttl
+++ b/config/migrations/2026/20260615120000-add-legal-forms-codelist.ttl
@@ -1,7 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix mu: <http://mu.semte.ch/vocabularies/core/> .
-@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix code: <http://lblod.data.gift/vocabularies/organisatie/> .
 @prefix conceptscheme: <http://data.vlaanderen.be/id/conceptscheme/> .
 @prefix concept: <http://data.vlaanderen.be/id/concept/LegalFormCode/> .
 
@@ -12,7 +12,7 @@ conceptscheme:LegalFormCode
 
 # Legal Form Codes
 concept:4a55b679-e4c7-4014-a0b8-3d6762e0225f
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "4a55b679-e4c7-4014-a0b8-3d6762e0225f" ;
   skos:prefLabel "Stad / gemeente" ;
@@ -20,7 +20,7 @@ concept:4a55b679-e4c7-4014-a0b8-3d6762e0225f
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:e87b0707-1f9c-4577-8918-023e60974d2f
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "e87b0707-1f9c-4577-8918-023e60974d2f" ;
   skos:prefLabel "Openbaar centrum voor maatschappelijk welzijn" ;
@@ -28,7 +28,7 @@ concept:e87b0707-1f9c-4577-8918-023e60974d2f
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:fa7b4356-6e67-4d3a-9256-72922a12227a
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "fa7b4356-6e67-4d3a-9256-72922a12227a" ;
   skos:prefLabel "Provinciale overheid" ;
@@ -36,7 +36,7 @@ concept:fa7b4356-6e67-4d3a-9256-72922a12227a
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:37e78d58-ab28-4047-8d23-4f2c09707c22
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "37e78d58-ab28-4047-8d23-4f2c09707c22" ;
   skos:prefLabel "Autonoom gemeentebedrijf" ;
@@ -44,7 +44,7 @@ concept:37e78d58-ab28-4047-8d23-4f2c09707c22
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:5a015434-4917-4124-a8ad-7f80d5300952
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "5a015434-4917-4124-a8ad-7f80d5300952" ;
   skos:prefLabel "Autonoom provinciebedrijf" ;
@@ -52,7 +52,7 @@ concept:5a015434-4917-4124-a8ad-7f80d5300952
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:107b192a-44e4-4d4b-aba7-e41aa6cc7f69
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "107b192a-44e4-4d4b-aba7-e41aa6cc7f69" ;
   skos:prefLabel "Projectvereniging" ;
@@ -60,7 +60,7 @@ concept:107b192a-44e4-4d4b-aba7-e41aa6cc7f69
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:960f8bb1-ea5d-40d7-bbf4-dbc0794afd26
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "960f8bb1-ea5d-40d7-bbf4-dbc0794afd26" ;
   skos:prefLabel "Dienstverlenende vereniging (Vlaams Gewest)" ;
@@ -68,7 +68,7 @@ concept:960f8bb1-ea5d-40d7-bbf4-dbc0794afd26
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:574a4cfb-7958-463a-9f4c-d9c4b250847c
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "574a4cfb-7958-463a-9f4c-d9c4b250847c" ;
   skos:prefLabel "Opdrachthoudende vereniging (Vlaams Gewest)" ;
@@ -76,7 +76,7 @@ concept:574a4cfb-7958-463a-9f4c-d9c4b250847c
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:c28b64ce-bb6c-4f8f-b03f-51dc09ae6748
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "c28b64ce-bb6c-4f8f-b03f-51dc09ae6748" ;
   skos:prefLabel "Lokale politiezone" ;
@@ -84,7 +84,7 @@ concept:c28b64ce-bb6c-4f8f-b03f-51dc09ae6748
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:75b075c8-1076-4ea3-9bc3-366f6cf866f4
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "75b075c8-1076-4ea3-9bc3-366f6cf866f4" ;
   skos:prefLabel "Hulpverleningszone" ;
@@ -92,7 +92,7 @@ concept:75b075c8-1076-4ea3-9bc3-366f6cf866f4
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:dbdd09f3-55b1-48bc-ac51-2c87f951860a
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "dbdd09f3-55b1-48bc-ac51-2c87f951860a" ;
   skos:prefLabel "Vereniging zonder winstoogmerk" ;
@@ -100,7 +100,7 @@ concept:dbdd09f3-55b1-48bc-ac51-2c87f951860a
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:925fbdb3-4693-4dcf-b75e-0a98985b1785
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "925fbdb3-4693-4dcf-b75e-0a98985b1785" ;
   skos:prefLabel "Internationale vereniging zonder winstoogmerk" ;
@@ -108,7 +108,7 @@ concept:925fbdb3-4693-4dcf-b75e-0a98985b1785
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:f25de736-bbc3-4e73-b401-5ee0b277f5f8
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "f25de736-bbc3-4e73-b401-5ee0b277f5f8" ;
   skos:prefLabel "Private stichting" ;
@@ -116,7 +116,7 @@ concept:f25de736-bbc3-4e73-b401-5ee0b277f5f8
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:9f578b10-255a-4403-ab4c-5d4415c30a0a
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "9f578b10-255a-4403-ab4c-5d4415c30a0a" ;
   skos:prefLabel "Stichting van openbaar nut" ;
@@ -124,7 +124,7 @@ concept:9f578b10-255a-4403-ab4c-5d4415c30a0a
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:30fb3516-fc48-453b-b1f6-a571d149ca3a
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "30fb3516-fc48-453b-b1f6-a571d149ca3a" ;
   skos:prefLabel "Maatschap" ;
@@ -132,7 +132,7 @@ concept:30fb3516-fc48-453b-b1f6-a571d149ca3a
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:7e31d057-fde3-47f3-ad89-3efd9e22ab08
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "7e31d057-fde3-47f3-ad89-3efd9e22ab08" ;
   skos:prefLabel "Vennootschap onder firma" ;
@@ -140,7 +140,7 @@ concept:7e31d057-fde3-47f3-ad89-3efd9e22ab08
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:cab6c3f9-aeee-48f0-88eb-c404310870ad
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "cab6c3f9-aeee-48f0-88eb-c404310870ad" ;
   skos:prefLabel "Commanditaire vennootschap" ;
@@ -148,7 +148,7 @@ concept:cab6c3f9-aeee-48f0-88eb-c404310870ad
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:8aa6149a-0916-42ed-a907-f760c0720527
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "8aa6149a-0916-42ed-a907-f760c0720527" ;
   skos:prefLabel "Besloten Vennootschap" ;
@@ -156,7 +156,7 @@ concept:8aa6149a-0916-42ed-a907-f760c0720527
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:e85bdc30-a69f-48f2-bc08-d32b640b1730
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "e85bdc30-a69f-48f2-bc08-d32b640b1730" ;
   skos:prefLabel "Naamloze vennootschap" ;
@@ -164,7 +164,7 @@ concept:e85bdc30-a69f-48f2-bc08-d32b640b1730
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:f35352d5-9454-4561-916a-f5f6459bc92b
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "f35352d5-9454-4561-916a-f5f6459bc92b" ;
   skos:prefLabel "Coöperatieve vennootschap" ;
@@ -172,7 +172,7 @@ concept:f35352d5-9454-4561-916a-f5f6459bc92b
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:205d4e7b-d6cc-4534-8336-7fae98dc139e
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "205d4e7b-d6cc-4534-8336-7fae98dc139e" ;
   skos:prefLabel "Organisme voor de Financiering van Pensioenen" ;
@@ -180,9 +180,33 @@ concept:205d4e7b-d6cc-4534-8336-7fae98dc139e
   skos:inScheme conceptscheme:LegalFormCode .
 
 concept:aa2590a0-b6de-4cba-982c-27d70553b17e
-  rdf:type ext:LegalForm ;
+  rdf:type code:Rechtsvormtype ;
   rdf:type skos:Concept ;
   mu:uuid "aa2590a0-b6de-4cba-982c-27d70553b17e" ;
   skos:prefLabel "Andere" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:b4f2c3d5-8a7e-4f1b-9c2d-3e5f6a7b8c9d
+  rdf:type code:Rechtsvormtype ;
+  rdf:type skos:Concept ;
+  mu:uuid "b4f2c3d5-8a7e-4f1b-9c2d-3e5f6a7b8c9d" ;
+  skos:prefLabel "Autonome verzorgingsinstelling" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:c7d8e9f0-1a2b-4c5d-6e7f-8a9b0c1d2e3f
+  rdf:type code:Rechtsvormtype ;
+  rdf:type skos:Concept ;
+  mu:uuid "c7d8e9f0-1a2b-4c5d-6e7f-8a9b0c1d2e3f" ;
+  skos:prefLabel "Welzijnsvereniging" ;
+  skos:topConceptOf conceptscheme:LegalFormCode ;
+  skos:inScheme conceptscheme:LegalFormCode .
+
+concept:d1e2f3a4-5b6c-7d8e-9f0a-1b2c3d4e5f6a
+  rdf:type code:Rechtsvormtype ;
+  rdf:type skos:Concept ;
+  mu:uuid "d1e2f3a4-5b6c-7d8e-9f0a-1b2c3d4e5f6a" ;
+  skos:prefLabel "Geen rechtspersoonlijkheid" ;
   skos:topConceptOf conceptscheme:LegalFormCode ;
   skos:inScheme conceptscheme:LegalFormCode .

--- a/config/migrations/2026/20260615170000-add-legal-form-change-event-type.sparql
+++ b/config/migrations/2026/20260615170000-add-legal-form-change-event-type.sparql
@@ -1,0 +1,11 @@
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concepts/8a4f3c2d-9e1b-4f5a-b7c3-6d8e9f0a1b2c>
+      a <http://lblod.data.gift/vocabularies/organisatie/Veranderingsgebeurtenis> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> "8a4f3c2d-9e1b-4f5a-b7c3-6d8e9f0a1b2c" ;
+      <http://www.w3.org/2004/02/skos/core#prefLabel> "Wijziging juridische vorm" ;
+      <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b> ;
+      <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/e1ff33ee76b5662ec8486f0e2abec384> ;
+      <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/e1ff33ee76b5662ec8486f0e2abec384> .
+  }
+}

--- a/config/resources/change-events.json
+++ b/config/resources/change-events.json
@@ -67,6 +67,11 @@
           "target": "organization-status-codes",
           "cardinality": "one"
         },
+        "resulting-legal-form": {
+          "predicate": "code:resulterendeRechtsvorm",
+          "target": "legal-form-codes",
+          "cardinality": "one"
+        },
         "result-from": {
           "predicate": "code:veranderingsgebeurtenisResultaat",
           "target": "change-events",

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -950,6 +950,12 @@
     "legal-form-codes": {
       "class": "code:Rechtsvormtype",
       "super": ["concepts"],
+      "attributes": {
+        "order": {
+          "type": "number",
+          "predicate": "ext:order"
+        }
+      },
       "new-resource-base": "http://data.vlaanderen.be/id/concept/LegalFormCode/"
     },
     "organization-status-codes": {

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -404,6 +404,11 @@
           "target": "organization-classification-codes",
           "cardinality": "one"
         },
+        "legal-form": {
+          "predicate": "organisatie:rechtsvorm",
+          "target": "legal-form-codes",
+          "cardinality": "one"
+        },
         "identifiers": {
           "predicate": "adms:identifier",
           "target": "identifiers",
@@ -941,6 +946,11 @@
         }
       },
       "new-resource-base": "http://lblod.data.gift/concepts/"
+    },
+    "legal-form-codes": {
+      "class": "ext:LegalForm",
+      "super": ["concepts"],
+      "new-resource-base": "http://data.vlaanderen.be/id/concept/LegalFormCode/"
     },
     "organization-status-codes": {
       "class": "code:OrganisatieStatusCode",

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -948,7 +948,7 @@
       "new-resource-base": "http://lblod.data.gift/concepts/"
     },
     "legal-form-codes": {
-      "class": "ext:LegalForm",
+      "class": "code:Rechtsvormtype",
       "super": ["concepts"],
       "new-resource-base": "http://data.vlaanderen.be/id/concept/LegalFormCode/"
     },


### PR DESCRIPTION

- Added Juridische vorm [OP-3816]
- Added change-event to change juridische vorm [OP-3820]

NOTE:
- Made juridische vorm not required because migration to fill in existing organizations will come later
- Juridische vorm is needed for organizations and registered organizations except worship administrative units. At the moment i put it on organizations because I don't really see a way of adding it elsewhere. This seems a bit weird because worship administrative units is a subclass of organizations.
- Regarding the change-event, I looked at the existing code regarding the status change via change-events and implemented it in a similar way. I think maybe it would be interesting to look at a change-event-service that would make changes via a config based on a newly created change-event delta.
